### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
         
       - name: Build And Publish Image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: khoonebemoon/khoonebemoon
           tags: latest


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore